### PR TITLE
Update year offset

### DIFF
--- a/Bahn-for-Watchy.ino
+++ b/Bahn-for-Watchy.ino
@@ -70,7 +70,7 @@ class WatchFace : public Watchy { //inherit and extend Watchy class
       lasty += -8-h;
 
       // draw year
-      textstring = currentTime.Year + 1970;
+      textstring = currentTime.Year + 2000;
       display.getTextBounds(textstring, 0, 0, &x1, &y1, &w, &h);
       display.setCursor(16, lasty);
       display.print(textstring);


### PR DESCRIPTION
The sqfmi/Watchy commit [241f568e713cf8b8d2014f85ce35cfada5ba405a](https://github.com/sqfmi/Watchy/commit/241f568e713cf8b8d2014f85ce35cfada5ba405a#diff-c24f78b3519d763901eb9f67b864f01d802d803df1b24faaf154019cf812bf95) changed the default year offset in `config.h` from 1970 to 2000, making this repository show the current year as 1991 rather than 2021. This patch fixes the issue by updating the offset in `Bahn-for-Watchy.ino`.